### PR TITLE
Render graphical previews of found patterns

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,9 @@
   <script defer src="script.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; }
-    .pattern { margin: 10px 0; }
+    #patternList { list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 20px; }
+    .pattern { margin: 10px; text-align: center; }
+    .pattern canvas { border: 1px solid #ccc; display: block; margin-top: 5px; }
   </style>
 </head>
 <body>

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,32 @@
+function drawPattern(canvas, pattern) {
+  const cellSize = 20;
+  canvas.width = canvas.height = pattern.gridSize * cellSize;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = '#eee';
+  for (let i = 0; i <= pattern.gridSize; i++) {
+    ctx.beginPath();
+    ctx.moveTo(i * cellSize, 0);
+    ctx.lineTo(i * cellSize, canvas.height);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, i * cellSize);
+    ctx.lineTo(canvas.width, i * cellSize);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = 'rgba(0, 150, 255, 0.5)';
+  ctx.strokeStyle = '#000';
+  pattern.squares.forEach(sq => {
+    const x = sq.x * cellSize;
+    const y = sq.y * cellSize;
+    const size = sq.size * cellSize;
+    ctx.fillRect(x, y, size, size);
+    ctx.strokeRect(x, y, size, size);
+  });
+}
+
 async function fetchPatterns() {
   const res = await fetch('/patterns');
   const data = await res.json();
@@ -6,7 +35,12 @@ async function fetchPatterns() {
   data.forEach((p, idx) => {
     const li = document.createElement('li');
     li.className = 'pattern';
-    li.textContent = `Pattern ${idx + 1}: ${p.squares.length} squares`;
+    const label = document.createElement('div');
+    label.textContent = `Pattern ${idx + 1}: ${p.squares.length} squares`;
+    const canvas = document.createElement('canvas');
+    drawPattern(canvas, p);
+    li.appendChild(label);
+    li.appendChild(canvas);
     list.appendChild(li);
   });
 }


### PR DESCRIPTION
## Summary
- Render each pattern on a canvas to visualize square layouts
- Style pattern list for a flexible grid and bordered canvases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ac5f9713c8333ac46c722643ae913