### PR TITLE
Show tiled preview of patterns

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -10,9 +10,9 @@
 - [x] Filter out non-tileable patterns and record discarded attempts.
 
 - [x] Do not allow patterns or tiles that have spaces in between the squares
+- [x] For successful patterns, show how they look if tiled
 
 ## Remaining
-- [ ] For successful patterns, show how they look if tiled
 - [ ] Add user controls for configuring search parameters.
 - [ ] Create automated tests for search logic and API endpoints.
 - [ ] Package app for deployment and provide containerization instructions.

--- a/public/script.js
+++ b/public/script.js
@@ -27,6 +27,40 @@ function drawPattern(canvas, pattern) {
   });
 }
 
+function getBoundingBox(squares) {
+  const xs = squares.map(s => [s.x, s.x + s.size]);
+  const ys = squares.map(s => [s.y, s.y + s.size]);
+  const minX = Math.min(...xs.map(v => v[0]));
+  const maxX = Math.max(...xs.map(v => v[1]));
+  const minY = Math.min(...ys.map(v => v[0]));
+  const maxY = Math.max(...ys.map(v => v[1]));
+  return { minX, minY, width: maxX - minX, height: maxY - minY };
+}
+
+function drawTiledPattern(canvas, pattern, tilesX = 3, tilesY = 3) {
+  const cellSize = 20;
+  const box = getBoundingBox(pattern.squares);
+  canvas.width = box.width * tilesX * cellSize;
+  canvas.height = box.height * tilesY * cellSize;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = 'rgba(0, 150, 255, 0.5)';
+  ctx.strokeStyle = '#000';
+
+  for (let ty = 0; ty < tilesY; ty++) {
+    for (let tx = 0; tx < tilesX; tx++) {
+      pattern.squares.forEach(sq => {
+        const x = (sq.x - box.minX + tx * box.width) * cellSize;
+        const y = (sq.y - box.minY + ty * box.height) * cellSize;
+        const size = sq.size * cellSize;
+        ctx.fillRect(x, y, size, size);
+        ctx.strokeRect(x, y, size, size);
+      });
+    }
+  }
+}
+
 async function fetchPatterns() {
   const res = await fetch('/patterns');
   const data = await res.json();
@@ -39,8 +73,11 @@ async function fetchPatterns() {
     label.textContent = `Pattern ${idx + 1}: ${p.squares.length} squares`;
     const canvas = document.createElement('canvas');
     drawPattern(canvas, p);
+    const tiledCanvas = document.createElement('canvas');
+    drawTiledPattern(tiledCanvas, p);
     li.appendChild(label);
     li.appendChild(canvas);
+    li.appendChild(tiledCanvas);
     list.appendChild(li);
   });
 }


### PR DESCRIPTION
## Summary
- Render repeating tiled versions of discovered patterns alongside their original form using a new `drawTiledPattern` helper.
- Track completion of the tiling preview feature in task list.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acdf023308333b71790ee690c2ab2